### PR TITLE
Serialize check_websites workflow runs across all callers

### DIFF
--- a/.github/workflows/bezirk_horgen.yml
+++ b/.github/workflows/bezirk_horgen.yml
@@ -14,6 +14,9 @@ on:
 
 jobs:
   notify_bez_horgen_websites:
+    concurrency:
+      group: check-websites
+      cancel-in-progress: false
     uses: metaodi/website-monitor/.github/workflows/check_websites.yml@main
     with:
       csv-path: csv/bezirk_horgen.csv

--- a/.github/workflows/job_websites.yml
+++ b/.github/workflows/job_websites.yml
@@ -15,6 +15,9 @@ on:
 
 jobs:
   notify_jobs_websites:
+    concurrency:
+      group: check-websites
+      cancel-in-progress: false
     uses: metaodi/website-monitor/.github/workflows/check_websites.yml@main
     with:
       csv-path: csv/jobs.csv

--- a/.github/workflows/rueschlikon.yml
+++ b/.github/workflows/rueschlikon.yml
@@ -14,6 +14,9 @@ on:
 
 jobs:
   notify_rueschlikon_websites:
+    concurrency:
+      group: check-websites
+      cancel-in-progress: false
     uses: metaodi/website-monitor/.github/workflows/check_websites.yml@main
     with:
       csv-path: csv/rueschlikon.csv

--- a/.github/workflows/thalwil.yml
+++ b/.github/workflows/thalwil.yml
@@ -14,6 +14,9 @@ on:
 
 jobs:
   notify_thalwil_websites:
+    concurrency:
+      group: check-websites
+      cancel-in-progress: false
     uses: metaodi/website-monitor/.github/workflows/check_websites.yml@main
     with:
       csv-path: csv/thalwil.csv


### PR DESCRIPTION
All four scheduled workflows (bezirk_horgen, thalwil, job_websites,
rueschlikon) invoke the shared check_websites.yml reusable workflow,
whose update_hashes job commits and pushes to the same main branch.
Overlapping runs could race on notifications.jsonl, texts/, and CSV
exports. Add a shared concurrency group so only one run executes at
a time, queuing rather than cancelling in-flight runs.