### PR TITLE
Retry selector lookup before failing website checks

### DIFF
--- a/lib/website_hash.py
+++ b/lib/website_hash.py
@@ -24,6 +24,7 @@ import hashlib
 import logging
 import re
 import sys
+import time
 from pprint import pformat
 from bs4 import BeautifulSoup
 from docopt import docopt
@@ -33,6 +34,13 @@ import download as dl
 log = logging.getLogger(__name__)
 
 _WORD_RE = re.compile(r"\w")
+
+# A selector that isn't found is often a transient hiccup (a slow-rendering
+# page, a momentary bot-check page, a CDN edge serving a half-built
+# response) rather than the selector actually being wrong, so the whole
+# fetch is retried a few times before giving up.
+SELECTOR_RETRY_ATTEMPTS = 3
+SELECTOR_RETRY_DELAY_SECONDS = 5
 
 
 def _normalize_text(text):
@@ -112,15 +120,28 @@ def _get_html_text(url, selector, verify, dl_type):
     Returns:
         List of extracted text strings
     """
-    if dl_type == "static":
-        content = dl.download(url, verify=verify)
-    elif dl_type == "dynamic":
-        content = dl.download_with_selenium(url, selector)
-    else:
-        raise Exception(f"Invalid type: {dl_type}")
+    as_list = []
+    for attempt in range(1, SELECTOR_RETRY_ATTEMPTS + 1):
+        if dl_type == "static":
+            content = dl.download(url, verify=verify)
+        elif dl_type == "dynamic":
+            content = dl.download_with_selenium(url, selector)
+        else:
+            raise Exception(f"Invalid type: {dl_type}")
 
-    soup = BeautifulSoup(content, "html.parser")
-    as_list = soup.select(selector)
+        soup = BeautifulSoup(content, "html.parser")
+        as_list = soup.select(selector)
+        if as_list:
+            break
+
+        if attempt < SELECTOR_RETRY_ATTEMPTS:
+            log.warning(
+                f"Selector {selector} not found in {url} "
+                f"(attempt {attempt}/{SELECTOR_RETRY_ATTEMPTS}), "
+                f"retrying in {SELECTOR_RETRY_DELAY_SECONDS}s..."
+            )
+            time.sleep(SELECTOR_RETRY_DELAY_SECONDS)
+
     if not as_list:
         log.error(f"Selector {selector} not found in {url}")
         sys.exit(1)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,8 +89,16 @@ def mock_download(monkeypatch):
     """
     import website_hash
 
-    def _setup(*, static_html=None, rss_feed=None):
-        if static_html is not None:
+    # Tests don't want to actually wait out the selector-not-found retry delay.
+    monkeypatch.setattr(website_hash.time, "sleep", lambda seconds: None)
+
+    def _setup(*, static_html=None, static_html_sequence=None, rss_feed=None):
+        if static_html_sequence is not None:
+            responses = iter(static_html_sequence)
+            fetch = lambda *args, **kwargs: next(responses)
+            monkeypatch.setattr(website_hash.dl, "download", fetch)
+            monkeypatch.setattr(website_hash.dl, "download_with_selenium", fetch)
+        elif static_html is not None:
             monkeypatch.setattr(website_hash.dl, "download", lambda url, verify=True: static_html)
             monkeypatch.setattr(
                 website_hash.dl,

--- a/tests/test_website_hash.py
+++ b/tests/test_website_hash.py
@@ -58,6 +58,28 @@ class TestGetHtmlTextStatic:
         with pytest.raises(SystemExit):
             wh._get_html_text("https://example.com", ".nonexistent", True, "static")
 
+    def test_selector_not_found_retries_full_attempt_budget(
+        self, mock_download, static_simple_html
+    ):
+        """A selector missing on every attempt is retried, then gives up."""
+        mock_download(
+            static_html_sequence=[static_simple_html] * wh.SELECTOR_RETRY_ATTEMPTS
+        )
+        with pytest.raises(SystemExit):
+            wh._get_html_text("https://example.com", ".nonexistent", True, "static")
+
+    def test_selector_found_on_retry_succeeds(
+        self, mock_download, static_simple_html, static_multi_html
+    ):
+        """A selector missing on the first attempt but present later succeeds."""
+        mock_download(static_html_sequence=[static_simple_html, static_multi_html])
+        result = wh._get_html_text("https://example.com", "article", True, "static")
+        assert result == [
+            "Article 1", "First article content.",
+            "Article 2", "Second article content.",
+            "Article 3", "Third article content.",
+        ]
+
     def test_invalid_dl_type_raises(self, mock_download, static_simple_html):
         mock_download(static_html=static_simple_html)
         with pytest.raises(Exception, match="Invalid type"):


### PR DESCRIPTION
GitHub Actions logs show many "Selector not found" failures on sites
that return a normal 200 response and clearly have the selector on a
manual check moments later (e.g. VStA, Ortsmuseum Rüschlikon, Grüne
Kanton Zürich). The single fetch-and-check in _get_html_text had no
retry, so a transient blip (slow render, momentary bot-check page,
stale CDN edge) immediately failed the job. Retry the whole fetch up
to 3 times with a 5s delay before giving up.